### PR TITLE
Added settings to configure FtsQuery

### DIFF
--- a/Fts.Test/FtsSettingsTests.cs
+++ b/Fts.Test/FtsSettingsTests.cs
@@ -1,0 +1,234 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SoftCircuits.FullTextSearchQuery;
+
+namespace Fts.Test
+{
+	[TestClass]
+	public class FtsSettingsTests
+	{
+		[TestMethod]
+		public void WordsJoinedWithOr_WhenSettingTurnedOn()
+		{
+			var query = new FtsQuery(new FtsQuerySettings { DefaultConjunction = DefaultConjunctionType.Or });
+
+			var actual = query.Transform("\"dk product\" dkp dkp123");
+
+			const string expected = "\"dk product\" OR FORMSOF(INFLECTIONAL, dkp) OR FORMSOF(INFLECTIONAL, dkp123)";
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void TrailingWildcardAddedToWords_WhenSettingTurnedOn()
+		{
+			var query = new FtsQuery(new FtsQuerySettings { UseTrailingWildcardForAllWords = true });
+
+			var actual = query.Transform("\"dk product\" dkp dkp123");
+
+			const string expected = "\"dk product\" AND \"dkp*\" AND \"dkp123*\"";
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void InflectionalSearchIsNotUsed_WhenDefaultTermFormIsLiteral()
+		{
+			var query = new FtsQuery(new FtsQuerySettings { UseInflectionalSearch = false });
+
+			Assert.AreEqual("\"abc\"", query.Transform("abc"));
+
+			Assert.AreEqual("\"abc\" AND \"def\"", query.Transform("abc def"));
+
+			Assert.AreEqual("\"def\" AND NOT \"abc\"", query.Transform("-abc def"));
+
+			Assert.AreEqual("\"abc\" AND (\"def\" OR \"ghi\")", query.Transform("abc and (def or ghi)"));
+		}
+
+		[TestMethod]
+		public void HyphenIsNotParsedAsPunctuation_WhenHyphenIsDisabled()
+		{
+			var query = new FtsQuery(new FtsQuerySettings { DisabledPunctuation = new[] { '-' } });
+
+			var actual = query.Transform("t-shirt");
+
+			const string expected = "FORMSOF(INFLECTIONAL, t-shirt)";
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void TildeIsNotParsedAsPunctuation_WhenTildeIsDisabled()
+		{
+			var query = new FtsQuery(new FtsQuerySettings { DisabledPunctuation = new[] { '~' } });
+
+			var actual = query.Transform("~abc");
+
+			const string expected = "FORMSOF(INFLECTIONAL, ~abc)";
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void NearIsNotParsedAsPunctuation_WhenSingleAngleQuotationMarks_andPlusAreDisabled()
+		{
+			var query = new FtsQuery(new FtsQuerySettings { DisabledPunctuation = new[] { '<', '>', '+' } });
+
+			var actual = query.Transform("<+abc +def>");
+
+			const string expected = "FORMSOF(INFLECTIONAL, <+abc) AND FORMSOF(INFLECTIONAL, +def>)";
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void NearIsNotParsedAsOperator_WhenItsDisabledInSettings()
+		{
+			var query = new FtsQuery(new FtsQuerySettings { TreatNearAsOperator = false });
+
+			var actual = query.Transform("\"abc\" NEAR \"def\"");
+
+			const string expected = "\"abc\" AND FORMSOF(INFLECTIONAL, NEAR) AND \"def\"";
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void TrailingWildcardAddedToWords_WhenDefaultTermFormIsLiteral_andTrailingWildcardEnabled()
+		{
+			var query = new FtsQuery(new FtsQuerySettings
+			{
+				UseInflectionalSearch = false,
+				UseTrailingWildcardForAllWords = true
+			});
+
+			var actual = query.Transform("abc def ghi*");
+
+			const string expected = "\"abc*\" AND \"def*\" AND \"ghi*\"";
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void TrailingWildcardIsNotAddedToAnd_WhenDefaultTermFormIsLiteral_andTrailingWildcardEnabled()
+		{
+			var query = new FtsQuery(new FtsQuerySettings
+			{
+				UseInflectionalSearch = false,
+				UseTrailingWildcardForAllWords = true
+			});
+
+			var actual = query.Transform("abc AND def");
+
+			const string expected = "\"abc*\" AND \"def*\"";
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void TrailingWildcardIsNotAddedToOr_WhenDefaultTermFormIsLiteral_andTrailingWildcardEnabled()
+		{
+			var query = new FtsQuery(new FtsQuerySettings
+			{
+				UseInflectionalSearch = false,
+				UseTrailingWildcardForAllWords = true
+			});
+
+			var actual = query.Transform("abc OR def");
+
+			const string expected = "\"abc*\" OR \"def*\"";
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void TrailingWildcardIsNotAddedToAndOr_WhenDefaultTermFormIsLiteral_andTrailingWildcardEnabled()
+		{
+			var query = new FtsQuery(new FtsQuerySettings
+			{
+				UseInflectionalSearch = false,
+				UseTrailingWildcardForAllWords = true
+			});
+
+			var actual = query.Transform("abc and (def or ghi)");
+
+			const string expected = "\"abc*\" AND (\"def*\" OR \"ghi*\")";
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void WordsJoinedWithOr_andUsedTrailingWildcard_WhenBothSettingsTurnedOn()
+		{
+			var query = new FtsQuery(new FtsQuerySettings
+			{
+				DefaultConjunction = DefaultConjunctionType.Or,
+				UseTrailingWildcardForAllWords = true
+			});
+
+			var actual = query.Transform("\"dk product\" dkp dkp123");
+
+			const string expected = "\"dk product\" OR \"dkp*\" OR \"dkp123*\"";
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void TrailingWildcardAddedToAllWords_andPunctuationSkipped()
+		{
+			var query = new FtsQuery(new FtsQuerySettings
+			{
+				DefaultConjunction = DefaultConjunctionType.And,
+				UseInflectionalSearch = false,
+				UseTrailingWildcardForAllWords = true,
+				DisabledPunctuation = new[] { '~', '-', '+', '<', '>' }
+			});
+
+			var actual = query.Transform("\"dk product\" dkp OR <+dkp+123+> -ab-c AND ~def*");
+
+			const string expected = "\"dk product\" AND \"dkp*\" OR \"<+dkp+123+>*\" AND \"-ab-c*\" AND \"~def*\"";
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void QuotesAddedToWord_WhenQuotesEnabled()
+		{
+			var query = new FtsQuery(new FtsQuerySettings { EnabledPunctuation = new[] { '"' } });
+
+			var actual = query.Transform("\"dk product\" dkp123");
+
+			const string expected = "\"dk product\" AND FORMSOF(INFLECTIONAL, dkp123)";
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void ParenthesesParsedAsPunctuation_WhenParenthesesEnabledInSettings()
+		{
+			var query = new FtsQuery(new FtsQuerySettings
+			{
+				UseInflectionalSearch = false,
+				EnabledPunctuation = new[] { '(' }
+			});
+
+			var actual = query.Transform("abc and (def or ghi)");
+
+			const string expected = "\"abc\" AND (\"def\" OR \"ghi\")";
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void AdditionalStopWordsUsed_WhenStandardStopWordsDisabled()
+		{
+			var additionalStopWords = new[] { "aa", "bb", "cc" };
+			var query = new FtsQuery(new FtsQuerySettings { AdditionalStopWords = additionalStopWords });
+
+			var actual = query.Transform("aa AND cc");
+
+			const string expected = "";
+			Assert.AreEqual(expected, actual);
+			Assert.AreEqual(3, query.StopWords.Count);
+		}
+
+		[TestMethod]
+		public void AdditionalStopWordsUsed_WhenStandardStopWordsAdded()
+		{
+			var additionalStopWords = new[] { "aa", "bb", "cc" };
+			var query = new FtsQuery(new FtsQuerySettings
+				{ AddStandardStopWords = true, AdditionalStopWords = additionalStopWords });
+
+			var actual = query.Transform("aa AND cc");
+
+			const string expected = "";
+			Assert.AreEqual(expected, actual);
+			Assert.IsTrue(query.StopWords.Count > 3, "Expected actualCount to be greater than 3.");
+		}
+	}
+}

--- a/FullTextSearchQuery.sln.DotSettings
+++ b/FullTextSearchQuery.sln.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/IndentTagContent/@EntryValue">ZeroIndent</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=FORMSOF/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/FullTextSearchQuery/FtsQuerySettings.cs
+++ b/FullTextSearchQuery/FtsQuerySettings.cs
@@ -1,0 +1,71 @@
+﻿using System;
+
+namespace SoftCircuits.FullTextSearchQuery
+{
+	public class FtsQuerySettings
+	{
+		/// <summary>
+		/// If true, then standard list of FTS stopwords are added to the stopword list.
+		/// </summary>
+		public bool AddStandardStopWords { get; set; }
+
+		/// <summary>
+		/// Default conjunction between parsed words. Possible values: And, Or.
+		/// </summary>
+		public DefaultConjunctionType DefaultConjunction { get; set; } = DefaultConjunctionType.And;
+
+		/// <summary>
+		/// Use inflectional search or search by exact term by default.
+		/// </summary>
+		/// <remarks>
+		/// Inflectional finds all of the tenses of a word.
+		/// For example, if you passed in Start, Inflectional will find Start, Started, and Starting.
+		/// For nouns, Inflectional finds the single, plural, and possessive forms.
+		/// </remarks>
+		public bool UseInflectionalSearch { get; set; } = true;
+
+		/// <summary>
+		/// Add trailing wildcard for every parsed word to search by the beginning of words.
+		/// </summary>
+		public bool UseTrailingWildcardForAllWords { get; set; }
+
+		/// <summary>
+		/// Treat <b>NEAR</b> term as operator.
+		/// </summary>
+		/// <remarks>
+		/// See more about FTS NEAR operator
+		/// <a href="http://docs.microsoft.com/en-us/sql/relational-databases/search/search-for-words-close-to-another-word-with-near">here.</a>
+		/// </remarks>
+		public bool TreatNearAsOperator { get; set; } = true;
+
+		/// <summary>
+		/// Enabled punctuation chars. If not empty then default list will be replaced with this one.
+		/// </summary>
+		/// <remarks>
+		/// Default punctuation chars:<![CDATA[~"`!@#$%^&*()-+=[]{}\|;:,.<>?/]]>
+		/// </remarks>
+		public char[] EnabledPunctuation { get; set; } = Array.Empty<char>();
+
+		/// <summary>
+		/// Disable punctuation chars.
+		/// </summary>
+		/// <remarks>
+		/// Default punctuation chars:<![CDATA[~"`!@#$%^&*()-+=[]{}\|;:,.<>?/]]>
+		/// </remarks>
+		public char[] DisabledPunctuation { get; set; } = Array.Empty<char>();
+
+		/// <summary>
+		/// Add additional stopwords.
+		/// </summary>
+		public string[] AdditionalStopWords { get; set; } = Array.Empty<string>();
+	}
+
+	/// <summary>
+	/// Term conjunction types.
+	/// </summary>
+	public enum DefaultConjunctionType
+	{
+		And,
+		Or
+	}
+}

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ The following list shows how various input are transformed.
 
 | Input | Output | Description |
 | ---- | ---- | ---- |
-| abc | `FORMSOF(INFLECTIONAL, abc)` | Find inflectional forms of abc.
-| ~abc | `FORMSOF(THESAURUS, abc)` | Find thesaurus variations of abc.
+| abc | `FORMSOF(INFLECTIONAL, abc)` | Find inflectional* forms of abc.
+| ~abc | `FORMSOF(THESAURUS, abc)` | Find thesaurus* variations of abc.
 | "abc" | `"abc"` | Find exact term abc.
 | +abc | `"abc"` | Find exact term abc.
 | "abc" near "def" | `"abc" NEAR "def"` | Find exact term abc near exact term def.
@@ -29,6 +29,8 @@ The following list shows how various input are transformed.
 | abc or def | `FORMSOF(INFLECTIONAL, abc) OR FORMSOF(INFLECTIONAL, def)` | Find inflectional forms of either abc or def.
 | &lt;+abc +def&gt; | `"abc" NEAR "def"` | Find exact term abc near exact term def.
 | abc and (def or ghi) | `FORMSOF(INFLECTIONAL, abc) AND (FORMSOF(INFLECTIONAL, def) OR FORMSOF(INFLECTIONAL, ghi))` | Find inflectional forms of both abc and either def or ghi.
+* Inflectional finds all of the tenses of a word. For example, if you passed in Start, Inflectional will find Start, Started, and Starting. For nouns, Inflectional finds the single, plural, and possessive forms.
+* Thesaurus finds variations of a word, Start, Begin, etc. Essentially, words that have the same meaning.
 
 # Preventing SQL Server Errors
 Even after a syntactically correct query has been generated, SQL Server can still generate an error for some queries. For example, in the table above you can see that the ouput for `-abc def` swaps the two subexpressions. This is because `NOT FORMSOF(INFLECTIONAL, abc) AND FORMSOF(INFLECTIONAL, def)` will cause an error. SQL Server does not like the `NOT` at the start. In this example, FullTextSearchQuery will swaps the two subexpressions (on either side of `AND`).
@@ -51,6 +53,21 @@ Use the `Transform()` method to convert a search expression to a valid SQL Serve
 ```c#
 // Pass true to add the standard stop words
 FtsQuery ftsQuery = new FtsQuery(true);
+string searchTerm = ftsQuery.Transform(text);
+```
+
+```c#
+// Pass extended settings to configure FtsQuery
+FtsQuery ftsQuery = new FtsQuery(new FtsQuerySettings
+{
+	AddStandardStopWords = true,
+	UseInflectionalSearch = true,
+	TreatNearAsOperator = true,
+	UseTrailingWildcardForAllWords = false,
+	DefaultConjunction = DefaultConjunctionType.And,
+	DisabledPunctuation = new[] { '-' },
+	AdditionalStopWords = new[] { "car" }
+});
 string searchTerm = ftsQuery.Transform(text);
 ```
 


### PR DESCRIPTION
Created FtsQuerySettings to change the default behavior of the FtsQuery. 

These settings allow:
- Enable/Disable adding the standard list of FTS stopwords to the stopword list.
- Adding additional stopwords. 
- Select default conjunction between parsed words. Possible values: And, Or.
- Select default search: inflectional or search by exact term.
- Adding trailing wildcard for every parsed word to search by the beginning of words.
- Enable/Disable parsing NEAR term as operator.
- Enable/Disable punctuation chars.

